### PR TITLE
fix GetJob function error check after nomad job api call

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.11.2 as build-env
+FROM golang:1.14.2 as build-env
 COPY . /go/src/github.com/trivago/scalad
 WORKDIR /go/src/github.com/trivago/scalad
 RUN go get
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /scalad
 
-FROM scratch 
+FROM scratch
 
 # Copy root filesystem
 COPY rootfs /

--- a/main.go
+++ b/main.go
@@ -482,13 +482,12 @@ func GetJob(jobID string, region string) (nomad.Job, error) {
 	options := &api.QueryOptions{AllowStale: true}
 
 	nomadJobPointer, _, err := client.Jobs().Info(jobID, options)
-
-	nomadJob = *nomadJobPointer
 	if err != nil {
-		log.Error("Unable to get job for", jobID, " from nomad with err: ", err)
+		log.Error("Unable to get job for ", jobID, " from nomad with err: ", err)
 		return nomadJob, err
 	}
 
+	nomadJob = *nomadJobPointer
 	return nomadJob, nil
 
 }


### PR DESCRIPTION
The function tries to deference the pointer to the return nomad job object, before checking for error from the jobs api call. This causes a null pointer dereference error and scalad becomes unresponsive to subsequence requests.

Ran and tested on nomad v0.10.5, scalad doesn't become unresponsive on resuming for a job that doesn't exist (No null pointer dereference error), and continues to operate normally